### PR TITLE
Rename Sentry modules so that they are unique to Intercom

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1594,7 +1594,7 @@
 		844DA7F6282435CD00E6B62E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		844DA80328246D5000E6B62E /* .oclint */ = {isa = PBXFileReference; lastKnownFileType = text; path = .oclint; sourceTree = "<group>"; };
 		844DA80428246D5000E6B62E /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		844DA80528246D5000E6B62E /* Sentry.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Sentry.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		844DA80528246D5000E6B62E /* Sentry_Intercom.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Sentry_Intercom.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		844DA80628246D5000E6B62E /* .craft.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .craft.yml; sourceTree = "<group>"; };
 		844DA80728246D5000E6B62E /* Gemfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Gemfile; sourceTree = "<group>"; };
 		844DA80828246D5000E6B62E /* .gitmodules */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitmodules; sourceTree = "<group>"; };
@@ -1741,7 +1741,7 @@
 		D81A346B291AECC7005A27A9 /* PrivateSentrySDKOnly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrivateSentrySDKOnly.h; path = include/HybridPublic/PrivateSentrySDKOnly.h; sourceTree = "<group>"; };
 		D81A3488291D0AC0005A27A9 /* SentryPrivate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SentryPrivate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D81A349B291D0C0B005A27A9 /* Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sentry.swift; sourceTree = "<group>"; };
-		D81A349F291D5568005A27A9 /* SentryPrivate.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = SentryPrivate.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		D81A349F291D5568005A27A9 /* SentryPrivate_Intercom.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = SentryPrivate_Intercom.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		D81A34A0291D5715005A27A9 /* SentryPrivate.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SentryPrivate.xcconfig; sourceTree = "<group>"; };
 		D81FDF10280EA0080045E0E4 /* SentryScreenShotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryScreenShotTests.swift; sourceTree = "<group>"; };
 		D8292D7A2A38AF04009872F7 /* HTTPHeaderSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeaderSanitizer.swift; sourceTree = "<group>"; };
@@ -2082,8 +2082,8 @@
 				844DA81028246D5000E6B62E /* CONTRIBUTING.md */,
 				844DA80E28246D5000E6B62E /* LICENSE.md */,
 				844DA80F28246D5000E6B62E /* README.md */,
-				844DA80528246D5000E6B62E /* Sentry.podspec */,
-				D81A349F291D5568005A27A9 /* SentryPrivate.podspec */,
+				844DA80528246D5000E6B62E /* Sentry_Intercom.podspec */,
+				D81A349F291D5568005A27A9 /* SentryPrivate_Intercom.podspec */,
 				D8199DD029377C130074249E /* SentrySwiftUI.podspec */,
 				844DA80D28246D5000E6B62E /* Package.swift */,
 				84C47B2B2A09239100DAEB8A /* .codecov.yml */,

--- a/SentryPrivate_Intercom.podspec
+++ b/SentryPrivate_Intercom.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "SentryPrivate"
+  s.name         = "SentryPrivate_Intercom"
   s.version      = "8.20.0"
   s.summary      = "Sentry Private Library."
   s.homepage     = "https://github.com/getsentry/sentry-cocoa"
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "11.0"
   s.watchos.deployment_target = "4.0"
   s.visionos.deployment_target = "1.0"
-  s.module_name  = "SentryPrivate"
+  s.module_name  = "SentryPrivate_Intercom"
   s.frameworks = 'Foundation'
 
   s.swift_versions = "5.5"

--- a/Sentry_Intercom.podspec
+++ b/Sentry_Intercom.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "Sentry"
+  s.name         = "Sentry_Intercom"
   s.version      = "8.20.0"
   s.summary      = "Sentry client for cocoa"
   s.homepage     = "https://github.com/getsentry/sentry-cocoa"
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "11.0"
   s.watchos.deployment_target = "4.0"
   s.visionos.deployment_target = "1.0"
-  s.module_name  = "Sentry"
+  s.module_name  = "Sentry_Intercom"
   s.requires_arc = true
   s.frameworks = 'Foundation'
   s.swift_versions = "5.5"
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   }
 
   s.default_subspecs = ['Core']
-  s.dependency "SentryPrivate", "8.20.0"
+  s.dependency "SentryPrivate_Intercom", "8.20.0"
 
   s.subspec 'Core' do |sp|
       sp.source_files = "Sources/Sentry/**/*.{h,hpp,m,mm,c,cpp}",

--- a/Sources/Sentry/SentryCoreDataTracker.m
+++ b/Sources/Sentry/SentryCoreDataTracker.m
@@ -9,7 +9,7 @@
 #import "SentrySDK+Private.h"
 #import "SentryScope+Private.h"
 #import "SentrySpanProtocol.h"
-@import SentryPrivate;
+@import SentryPrivate_Intercom;
 #import "SentrySpan.h"
 #import "SentryStacktrace.h"
 #import "SentryThreadInspector.h"

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -25,7 +25,7 @@
 #import "SentryTracer.h"
 #import "SentryUser.h"
 #import <objc/runtime.h>
-@import SentryPrivate;
+@import SentryPrivate_Intercom;
 
 /**
  * WARNING: We had issues in the past with this code on older iOS versions. We don't run unit tests

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -28,7 +28,7 @@
 #import <SentryDispatchQueueWrapper.h>
 #import <SentryMeasurementValue.h>
 #import <SentrySpanOperations.h>
-@import SentryPrivate;
+@import SentryPrivate_Intercom;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 #    import "SentryProfiledTracerConcurrency.h"

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -1,7 +1,7 @@
 #import "SentryUIApplication.h"
 #import "SentryDependencyContainer.h"
 #import "SentryDispatchQueueWrapper.h"
-@import SentryPrivate;
+@import SentryPrivate_Intercom;
 #import "SentryNSNotificationCenterWrapper.h"
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -10,7 +10,7 @@
 #    import "SentryUIApplication.h"
 #    import <UIKit/UIKit.h>
 
-@import SentryPrivate;
+@import SentryPrivate_Intercom;
 
 static int
 writeJSONDataToFile(const char *const data, const int length, void *const userData)

--- a/Sources/Sentry/include/SentrySwift.h
+++ b/Sources/Sentry/include/SentrySwift.h
@@ -1,6 +1,6 @@
 #ifndef SentrySwift_h
 #define SentrySwift_h
 
-@import SentryPrivate;
+@import SentryPrivate_Intercom;
 
 #endif

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMXCallStackTreeTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMXCallStackTreeTests.swift
@@ -1,5 +1,5 @@
 #if os(iOS) || os(macOS)
-import SentryPrivate
+import SentryPrivate_Intercom
 import XCTest
 
 /**

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -1,5 +1,5 @@
 import Sentry
-import SentryPrivate
+import SentryPrivate_Intercom
 import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -205,7 +205,7 @@
 #import "TestSentryCrashWrapper.h"
 #import "TestSentrySpan.h"
 #import "URLSessionTaskMock.h"
-@import SentryPrivate;
+@import SentryPrivate_Intercom;
 #import "SentryBinaryImageCache+Private.h"
 #import "SentryCrashBinaryImageCache.h"
 #import "SentryDispatchFactory.h"

--- a/Tests/SentryTests/UrlSanitizedTests.swift
+++ b/Tests/SentryTests/UrlSanitizedTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SentryPrivate
+import SentryPrivate_Intercom
 import XCTest
 
 class UrlSanitizedTests: XCTestCase {


### PR DESCRIPTION
- Addresses https://github.com/intercom/intercom/issues/322029
- Sentry module names were causing namespace collisions with customers' apps because `SentryPrivate` module name could not be mangled by us.
- Solution is to fork Sentry and manually rename `Sentry` and `SentryPrivate` to be unique to Intercom.

